### PR TITLE
add geojson-multiply

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ GeoJSON utilities that will make your life easier.
 * [geojson-coords](https://github.com/mapbox/geojson-coords): Extract coordinates from GeoJSON
 * [geojson-extent](https://www.npmjs.com/package/geojson-extent): compute the bounding box of geojson features
 * [geojson-flatten](https://github.com/mapbox/geojson-flatten): flatten multi geometries into normal geometries
+* [geojson-multiply](https://github.com/haoliangyu/geojson-multiply):  merge normal geojson features into one multi geometry type feature
 * [geojson-js-utils](https://github.com/maxogden/geojson-js-utils): JavaScript helper functions for manipulating GeoJSON
 * [geojson-merge](https://github.com/mapbox/geojson-merge): Merge multiple GeoJSON files into one FeatureCollection.
 * [geojson-normalize](https://github.com/mapbox/geojson-normalize): normalize any geojson object into a geojson featurecollection


### PR DESCRIPTION
The `geojson-multiply` package merges single geometry type features into one multi geometry feature. It also accepts an aggregation function to aggregate properties, similar to [Array.reduce()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce). This is a reversed process of `geojson-fatten`. I create this package to help me prepare geojson for some PostGIS functions that accept multi-geometry. I think it would be helpful to other people.