### PR TITLE
Add iNaturalist to data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ GeoJSON utilities that will make your life easier.
 * [99boundaries](https://github.com/TimMcCauley/nintynine-boundaries): Generate any maritime & land boundary in GeoJSON and other file formats or [download directly from the web](https://99boundaries.com)
 * [france-geojson](https://github.com/gregoiredavid/france-geojson): Outlines of regions, departments, arrondissements, cantons and communes of France (mainland and overseas departments) in GeoJSON format
 * [zg3d](https://data.zagreb.hr/dataset/zg3d-2022-3d-model-gz): 3D models of existing buildings in the City of Zagreb, Croatia in GeoJSON (CSV and Excel also available).
+* [iNaturalist](https://api.inaturalist.org/v1/): REST API serving 300M+ species occurrence observations, each with a GeoJSON Point geometry (latitude/longitude) across 300K+ taxa.
 
 ### serialization
 


### PR DESCRIPTION
The data section covers real-world GeoJSON data sources but has no species occurrence data. The iNaturalist REST API returns each observation with a \`geojson\` field (GeoJSON Point geometry). With 300M+ records across 300K+ taxa, it is the largest open species occurrence dataset accessible via API without authentication.

\`\`\`
GET https://api.inaturalist.org/v1/observations
# Each record includes: {"geojson": {"type": "Point", "coordinates": [lon, lat]}}
\`\`\`