### PR TITLE
Add MapAtlas to services

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ GeoJSON utilities that will make your life easier.
 * [koop](https://koopjs.github.io): Server with plugins that recast Esri, GitHub, Socrata and other services as GeoJSON endpoints
 * [featureserver](https://github.com/featureserver/featureserver): An open source Esri-Style Feature Server
 * [geojson minify](https://open-innovations.github.io/geojson-minify/): Minifier (compressor) to reduce file sizes
+* [MapAtlas](https://mapatlas.eu): REST API for geocoding, routing, isochrones, and map matching with GeoJSON output
 
 ### conversion
 


### PR DESCRIPTION
Adding MapAtlas to the services section.

MapAtlas is a REST API for geocoding, routing, isochrones, and map matching that returns GeoJSON output. Built on OpenStreetMap data, EU-hosted.

Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V., the company behind MapAtlas.