### PR TITLE
Add Europe Beach Map to data

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ GeoJSON utilities that will make your life easier.
 * [99boundaries](https://github.com/TimMcCauley/nintynine-boundaries): Generate any maritime & land boundary in GeoJSON and other file formats or [download directly from the web](https://99boundaries.com)
 * [france-geojson](https://github.com/gregoiredavid/france-geojson): Outlines of regions, departments, arrondissements, cantons and communes of France (mainland and overseas departments) in GeoJSON format
 * [zg3d](https://data.zagreb.hr/dataset/zg3d-2022-3d-model-gz): 3D models of existing buildings in the City of Zagreb, Croatia in GeoJSON (CSV and Excel also available).
+* [Europe Beach Map](https://europebeachmap.com/data/beaches.geojson): 511 European beaches as GeoJSON points with sea temperature, sand type, best season and Blue Flag status (CC BY 4.0)
 
 ### serialization
 


### PR DESCRIPTION
Adds **Europe Beach Map** to the **data** section — 511 European beaches as a GeoJSON FeatureCollection (Point geometry per beach) with sea temperature, sand type, best season and Blue Flag status. Direct file: https://europebeachmap.com/data/beaches.geojson — open data under CC BY 4.0 (also mirrored on Zenodo with a DOI).

Disclosure: I'm the maker.