### PR TITLE
Add TrainRouter Atlas to data

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ GeoJSON utilities that will make your life easier.
 * [99boundaries](https://github.com/TimMcCauley/nintynine-boundaries): Generate any maritime & land boundary in GeoJSON and other file formats or [download directly from the web](https://99boundaries.com)
 * [france-geojson](https://github.com/gregoiredavid/france-geojson): Outlines of regions, departments, arrondissements, cantons and communes of France (mainland and overseas departments) in GeoJSON format
 * [zg3d](https://data.zagreb.hr/dataset/zg3d-2022-3d-model-gz): 3D models of existing buildings in the City of Zagreb, Croatia in GeoJSON (CSV and Excel also available).
+* [TrainRouter Atlas](https://github.com/Flightmussy/trainrouter-atlas): 744 notable world passenger train routes as GeoJSON — route geometry plus distance, journey time, top speed, operator and opening year. CC BY 4.0.
 
 ### serialization
 


### PR DESCRIPTION
Adds the [TrainRouter Atlas](https://github.com/Flightmussy/trainrouter-atlas) to the **data** section — 744 notable world passenger train routes as GeoJSON (route geometry + distance, journey time, top speed, operator, opening year), released CC BY 4.0 and archived on Zenodo (DOI 10.5281/zenodo.21322030). It sits alongside the Natural Earth / world-atlas reference-geodata entries. I built and maintain it. Thanks!