### PR TITLE
Add eudr-geojson-fixtures to validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ GeoJSON utilities that will make your life easier.
 * [Jest-GeoJSON](https://github.com/M-Scott-Lassiter/jest-geojson): an extended set of matcher functions for the Jest Javascript unit testing framework tailored to evaluating GeoJSON data
 * [antimeridian](https://github.com/gadomski/antimeridian): Fix GeoJSON polygons that cross the antimeridian (Python package)
 * [geojson-pydantic](https://github.com/developmentseed/geojson-pydantic): [Pydantic](https://docs.pydantic.dev/latest/) models for GeoJSON
+* [eudr-geojson-fixtures](https://github.com/vancebw/eudr-geojson-fixtures): test fixtures for EUDR geolocation data: valid plot examples plus common failure modes like axis swaps and self-intersecting rings
 
 ### services
 


### PR DESCRIPTION
Adds an open set of test fixtures for EUDR geolocation data to the validation section:

- valid examples: point plot ≤ 4 ha, polygon plot > 4 ha, MultiPolygon farm
- failure modes: swapped lon/lat (in range, wrong country), out-of-range coordinates, self-intersecting rings, unclosed rings, duplicate rings, missing plot ids, null geometry, malformed KML, swapped CSV columns

All coordinates are synthetic, MIT licensed. Felt like a natural neighbour to geojsonhint / check-geojson / Jest-GeoJSON for anyone testing validators rather than just running them.

Disclosure: I maintain the repo (built for Filovara, an EUDR compliance tool).